### PR TITLE
Added Microformats

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -13,28 +13,28 @@
     {{- end }}
     {{- $paginator := .Paginate $pages (index .Site.Params "archive-paginate" | default 20) }}
     {{- range $paginator.Pages  }}
-    <article>
+    <article class="h-entry">
     {{- if .Title }}
-        <h2 class="post-title"><a href="{{ .Permalink }}">{{ .Title }}</a></h2>
+        <h2 class="post-title"><a href="{{ .Permalink }}" class="u-url">{{ .Title }}</a></h2>
         <p class="post-date">{{- if .Site.Params.use_short_date }}{{ .Date | time.Format ":date_short" }}{{- else }}{{ .Date | time.Format ":date_full" }}{{- end }}</p>
         {{- if .Site.Params.show_full_post }}
         {{ .Content }}
         {{- else }}
         <p>{{ .Summary | safeHTML }}</p>
-        <p><a href="{{ .Permalink }}">{{ T "Continue reading" }} →</a></p>
+        <p><a href="{{ .Permalink }}" class="u-url">{{ T "Continue reading" }} →</a></p>
         {{- end }}
     {{- else if in .RawContent "<!--more-->"}}
-        <p class="post-date btm-margin"><a href="{{ .Permalink }}">{{- if .Site.Params.use_short_date }}{{ .Date | time.Format ":date_short" }}{{- else }}{{ .Date | time.Format ":date_full" }}{{- end }} →</a></p>
+        <p class="post-date btm-margin"><a href="{{ .Permalink }}" class="u-url">{{- if .Site.Params.use_short_date }}{{ .Date | time.Format ":date_short" }}{{- else }}{{ .Date | time.Format ":date_full" }}{{- end }} →</a></p>
         {{- if .Site.Params.show_full_post }}
         {{ .Content }}
         {{- else }}
         <p>{{ .Summary | safeHTML }}</p>
         {{- if .Truncated }}
-        <p><a href="{{ .Permalink }}">{{ T "Continue reading" }} →</a></p>
+        <p><a href="{{ .Permalink }}" class="u-url">{{ T "Continue reading" }} →</a></p>
         {{- end }}
         {{- end }}
     {{- else }}
-        <p class="post-date btm-margin"><a href="{{ .Permalink }}">{{- if .Site.Params.use_short_date }}{{ .Date | time.Format ":date_short" }}{{- else }}{{ .Date | time.Format ":date_full" }}{{- end }} →</a></p>
+        <p class="post-date btm-margin"><a href="{{ .Permalink }}" class="u-url">{{- if .Site.Params.use_short_date }}{{ .Date | time.Format ":date_short" }}{{- else }}{{ .Date | time.Format ":date_full" }}{{- end }} →</a></p>
         {{ .Content }}
     {{- end }}
     </article>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,8 +1,8 @@
 {{- define "main" }}
 <main>
-    <article>
+    <article class="h-entry">
         {{- if .Title }}
-        <h1 class="post-title">{{ .Title }}</h1>
+        <h1 class="post-title p-name">{{ .Title }}</h1>
         <p class="post-date">{{- if .Site.Params.use_short_date }}{{ .Date | time.Format ":date_short" }}{{- else }}{{ .Date | time.Format ":date_full" }}{{- end }}</p>
         {{- else }}
         <p class="post-date btm-margin">{{- if .Site.Params.use_short_date }}{{ .Date | time.Format ":date_short" }}{{- else }}{{ .Date | time.Format ":date_full" }}{{- end }}</p>
@@ -10,7 +10,9 @@
         {{- with .Params.audio }}
         <script type="text/javascript" src="https://micro.blog/narration.js?url={{ . }}"></script>
         {{- end }}
-        {{ .Content }}
+        <div class="e-content">
+            {{ .Content }}
+        </div>
         {{- if isset .Params "categories" }}
         <p class="categories">
         {{- range $index, $category := .Params.categories }}


### PR DESCRIPTION
While testing the new Mac app for Micro.blog, which looks for Microformats classes when trying to download a blog theme, I noticed that mnml doesn't really use Microformats. This pull request adds the bare minimum… Basically `h-entry` (for a post), `e-content` (for the content), and `u-url` (for permalinks). It doesn't appear to mess with the design, but I haven't tested it extensively comparing the current theme either.